### PR TITLE
Fixed error in Payback Period formula

### DIFF
--- a/finance.js
+++ b/finance.js
@@ -80,7 +80,7 @@ Finance.prototype.PP = function(numOfPeriods, cfs) {
   for (i = 2; i < arguments.length; i++) {
     cumulativeCashFlow += arguments[i];
     if (cumulativeCashFlow > 0) {
-      yearsCounter += (cumulativeCashFlow - arguments[i]) / arguments[i];
+      yearsCounter += -1 + Math.abs((cumulativeCashFlow - arguments[i]) / arguments[i]);
       return yearsCounter;
     } else {
       yearsCounter++;


### PR DESCRIPTION
## Fix for finance.PP  
### Summary of the problem  
The [payback period calculation](https://github.com/ebradyjobory/finance.js#payback-period-ppfinanceppnumber-of-periods-cash-flows) does not return the correct result. It includes and extra year, then subtracts the fractional final year instead of adding it.

### Demonstration of the problem  
The example, `finance.PP(5, -50, 10, 13, 16, 19, 22);`, says the pp is 3.42, but it should be **3.57895** (3 full years and .579 of the fourth year). We can see that in the cumulative return:
```
   0    1    2    3    4    <-- Years
-- | -- | -- | -- | -- | --
 -50   10   13   16   19    <-- Cash flows 
 -50  -40  -27  -11    8    <-- Cumulative return
```
After year 3, there is still $11 to recover. We'll get $19 in year 4, so we'll break even 11/19th of the way through year 4  
(`11/19 = 0.57895`). 

### Solution  
Small change in line 83 in [finance.js](https://github.com/ebradyjobory/finance.js/blob/master/finance.js):
>Current: ~~yearsCounter += (cumulativeCashFlow - arguments[i]) / arguments[i];~~
>Fixed: yearsCounter += -1 + Math.abs((cumulativeCashFlow - arguments[i]) / arguments[i]);